### PR TITLE
Add CUDA nibble filter

### DIFF
--- a/CudaKeySearchDevice/CudaKeySearchDevice.h
+++ b/CudaKeySearchDevice/CudaKeySearchDevice.h
@@ -66,10 +66,13 @@ private:
     secp256k1::uint256 _stride;
 
     bool verifyKey(const secp256k1::uint256 &privateKey, const secp256k1::ecpoint &publicKey, const unsigned int hash[5], bool compressed);
+    unsigned int *_devPrivateKeys;
+    unsigned int _nibbleLength;
 
 public:
 
     CudaKeySearchDevice(int device, int threads, int pointsPerThread, int blocks = 0);
+    ~CudaKeySearchDevice();
 
     virtual void init(const secp256k1::uint256 &start, int compression, const secp256k1::uint256 &stride);
 
@@ -86,6 +89,8 @@ public:
     virtual void getMemoryInfo(uint64_t &freeMem, uint64_t &totalMem);
 
     virtual secp256k1::uint256 getNextKey();
+
+    void setNibbleLength(unsigned int nibbleLength);
 };
 
 #endif

--- a/CudaKeySearchDevice/cudabridge.h
+++ b/CudaKeySearchDevice/cudabridge.h
@@ -13,6 +13,9 @@ void callKeyFinderKernel(int blocks, int threads, int points, bool useDouble, in
 void waitForKernel();
 
 cudaError_t setIncrementorPoint(const secp256k1::uint256 &x, const secp256k1::uint256 &y);
+cudaError_t setPrivateKeyIncrement(const secp256k1::uint256 &value);
+cudaError_t setPrivateKeyBuffer(unsigned int *ptr);
+cudaError_t setNibbleLimit(unsigned int nibble);
 cudaError_t allocateChainBuf(unsigned int count);
 void cleanupChainBuf();
 


### PR DESCRIPTION
## Summary
- add nibble filter support to the CUDA key search flow, including private-key tracking on device
- expose a new `--nibble` CLI option for configuring the repeat threshold and log/validate usage

## Testing
- make

------
https://chatgpt.com/codex/tasks/task_e_68cb661964b0832188922cb3afe0ae33