### PR TITLE
Adjust CUDA nibble filter handling

### DIFF
--- a/CudaKeySearchDevice/CudaKeySearchDevice.cpp
+++ b/CudaKeySearchDevice/CudaKeySearchDevice.cpp
@@ -92,6 +92,12 @@ void CudaKeySearchDevice::init(const secp256k1::uint256 &start, int compression,
     cudaCall(setNibbleLimit(_nibbleLength));
     cudaCall(setPrivateKeyBuffer(NULL));
 
+    if(_nibbleLength > 0) {
+        if(!runNibbleSequenceDiagnostics(_nibbleLength)) {
+            Logger::log(LogLevel::Warning, "Nibble filter diagnostics failed");
+        }
+    }
+
     generateStartingPoints();
 
     cudaCall(allocateChainBuf(_threads * _blocks * _pointsPerThread));

--- a/CudaKeySearchDevice/cudabridge.h
+++ b/CudaKeySearchDevice/cudabridge.h
@@ -18,5 +18,6 @@ cudaError_t setPrivateKeyBuffer(unsigned int *ptr);
 cudaError_t setNibbleLimit(unsigned int nibble);
 cudaError_t allocateChainBuf(unsigned int count);
 void cleanupChainBuf();
+bool runNibbleSequenceDiagnostics(unsigned int nibbleLength);
 
 #endif


### PR DESCRIPTION
## Summary
- skip leading zero nibbles before counting repetitions in the CUDA nibble filter while still flagging all-zero keys
- add CUDA-side diagnostics that exercise zero-leading and repeating-nibble keys to validate the filter logic
- run the diagnostics during device initialization when the nibble filter is enabled

## Testing
- make -C CudaKeySearchDevice *(fails: g++: error: missing path after ‘-I’)*

------
https://chatgpt.com/codex/tasks/task_e_68cb8917764c8321bf274961608389a6