### PR TITLE
Enable dynamic nibble filtering offsets

### DIFF
--- a/CudaKeySearchDevice/CudaKeySearchDevice.h
+++ b/CudaKeySearchDevice/CudaKeySearchDevice.h
@@ -64,6 +64,7 @@ private:
     uint32_t getPrivateKeyOffset(int thread, int block, int point);
 
     secp256k1::uint256 _stride;
+    secp256k1::uint256 _iterationKeyIncrement;
 
     bool verifyKey(const secp256k1::uint256 &privateKey, const secp256k1::ecpoint &publicKey, const unsigned int hash[5], bool compressed);
     unsigned int *_devPrivateKeys;

--- a/CudaKeySearchDevice/cudabridge.h
+++ b/CudaKeySearchDevice/cudabridge.h
@@ -14,6 +14,7 @@ void waitForKernel();
 
 cudaError_t setIncrementorPoint(const secp256k1::uint256 &x, const secp256k1::uint256 &y);
 cudaError_t setPrivateKeyIncrement(const secp256k1::uint256 &value);
+cudaError_t setIterationOffset(const secp256k1::uint256 &value);
 cudaError_t setPrivateKeyBuffer(unsigned int *ptr);
 cudaError_t setNibbleLimit(unsigned int nibble);
 cudaError_t allocateChainBuf(unsigned int count);


### PR DESCRIPTION
## Summary
- add a constant-memory iteration offset and host setter for CUDA nibble filtering
- derive candidate keys from the per-lane base key plus the uploaded offset so the private key buffer stays static
- retain the stride-derived increment on the host and refresh the device offset before each nibble-filtered kernel launch

## Testing
- `make BUILD_CUDA=1` *(fails: CUDA headers unavailable in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb891c1e74832186baebb842382a08