### PR TITLE
Accumulate elapsed time across keyspace entries

### DIFF
--- a/KeyFinder/main.cpp
+++ b/KeyFinder/main.cpp
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <fstream>
 #include <iostream>
+#include <limits>
 
 #include "KeyFinder.h"
 #include "AddressUtil.h"
@@ -452,6 +453,19 @@ int run()
         }
 
         f.run();
+
+        uint64_t now = util::getSystemTime();
+        if(_startTime != 0 && now >= _startTime) {
+            uint64_t elapsed = now - _startTime;
+            uint64_t newElapsed = static_cast<uint64_t>(_config.elapsed) + elapsed;
+            if(newElapsed > std::numeric_limits<unsigned int>::max()) {
+                newElapsed = std::numeric_limits<unsigned int>::max();
+            }
+            _config.elapsed = static_cast<unsigned int>(newElapsed);
+        }
+
+        _startTime = now;
+        _lastUpdate = now;
 
         delete d;
     } catch(KeySearchException ex) {


### PR DESCRIPTION
## Summary
- add `<limits>` include to support overflow-safe elapsed time accumulation
- accumulate elapsed time after each configured run and reset timing state

## Testing
- make -C KeyFinder

------
https://chatgpt.com/codex/tasks/task_e_68cb989e030083218dcf67c66eba9766